### PR TITLE
Update Audi Q3 generations: Correct model years, add generation 3, and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Audi Q3
 
+This repository contains signal set configurations for the Audi Q3, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,10 +1,18 @@
+references:
+  - "https://en.wikipedia.org/wiki/Audi_Q3"
+
 generations:
   - name: "First Generation (8U)"
-    start_year: 2011
+    start_year: 2015
     end_year: 2018
     description: "The original Audi Q3 was a compact luxury crossover SUV built on the Volkswagen Group A5 (PQ35) platform. It featured a design influenced by the larger Q5 but with more compact proportions. Engine options included four-cylinder TFSI petrol and TDI diesel units, with front-wheel drive or quattro all-wheel drive. A performance-oriented RS Q3 variant was introduced in 2013, featuring a turbocharged five-cylinder engine producing up to 367 HP in Performance trim. A facelift in 2014 updated the styling and technology offerings."
 
   - name: "Second Generation (F3)"
-    start_year: 2018
-    end_year: null
+    start_year: 2019
+    end_year: 2025
     description: "Built on the Volkswagen Group MQB platform, the second-generation Q3 grew in size with a longer wheelbase providing more interior space. It features more angular styling in line with Audi's latest design language. The interior represents a significant upgrade with digital instrumentation and improved infotainment systems. Engine options continue to include four-cylinder TFSI petrol and TDI diesel units with mild-hybrid technology available on some variants. The range includes the standard Q3, the coupe-inspired Q3 Sportback, and the high-performance RS Q3 with its distinctive five-cylinder engine producing 400 HP. The second-generation Q3 elevates the model's premium positioning with improved space, technology, and driving dynamics."
+
+  - name: "Third Generation (FJ)"
+    start_year: 2026
+    end_year: null
+    description: "The third-generation Audi Q3 unveiled in June 2025 represents a comprehensive redesign with inspiration drawn from the third-generation Q5. Built on the MQB Evo platform, it features a new design language with distinctive split headlights and updated proportions. The model takes design inspiration from Audi's latest design philosophy. Powertrain options include efficient turbocharged petrol and diesel units, with plug-in hybrid technology available. The new Q3 achieves improved efficiency and performance while maintaining the model's position as a premium compact crossover. Sales commenced in late 2025 for the 2026 model year."


### PR DESCRIPTION
- Fixed: Gen 1 (8U) start year corrected from 2011 to 2015 per Wikipedia model_years
- Fixed: Gen 2 (F3) years corrected from 2018-null to 2019-2025 per Wikipedia model_years
- Added: Generation 3 (FJ) 2026-present (unveiled June 2025)
- Added: Wikipedia references to generations.yaml
- Updated: README.md title from placeholder to "Audi Q3"

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
